### PR TITLE
chore(deps): Update SDK Core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v2-sdk"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V2 SDK for Rust"
@@ -19,5 +19,6 @@ alloy-sol-types = "0.7"
 anyhow = "1.0"
 once_cell = "1.19"
 ruint = "1.11"
+rustc-hash = "2.0"
 thiserror = "1.0"
-uniswap-sdk-core = "0.21.0"
+uniswap-sdk-core = { version = "1.0.0-rc", features = ["std"] }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{address, b256, Address, B256};
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use uniswap_sdk_core::{
     addresses::V2_FACTORY_ADDRESSES,
     prelude::{BigInt, Percent},
@@ -8,7 +8,7 @@ use uniswap_sdk_core::{
 
 pub const FACTORY_ADDRESS: Address = address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f");
 
-pub static FACTORY_ADDRESS_MAP: Lazy<HashMap<u64, Address>> =
+pub static FACTORY_ADDRESS_MAP: Lazy<FxHashMap<u64, Address>> =
     Lazy::new(|| V2_FACTORY_ADDRESSES.clone());
 
 pub const INIT_CODE_HASH: B256 =

--- a/src/entities/pair.rs
+++ b/src/entities/pair.rs
@@ -767,7 +767,7 @@ mod tests {
                         .get_output_amount(&input_blasters_amount, true)
                         .unwrap();
 
-                    assert_eq!(output_blast_amount.to_exact(), "0.00000000000000009");
+                    assert_eq!(output_blast_amount.to_exact(), "9E-17");
                 }
 
                 #[test]
@@ -784,7 +784,7 @@ mod tests {
                     let (input_blaster_amount, _) =
                         pair.get_input_amount(&output_blast_amount, true).unwrap();
 
-                    assert_eq!(input_blaster_amount.to_exact(), "0.000000101");
+                    assert_eq!(input_blaster_amount.to_exact(), "1.01E-7");
                 }
             }
 
@@ -806,7 +806,7 @@ mod tests {
                         .get_output_amount(&input_blasters_amount, false)
                         .unwrap();
 
-                    assert_eq!(output_blast_amount.to_exact(), "0.000000000000000098");
+                    assert_eq!(output_blast_amount.to_exact(), "9.8E-17");
                 }
 
                 #[test]
@@ -823,7 +823,7 @@ mod tests {
                     let (input_blaster_amount, _) =
                         pair.get_input_amount(&output_blast_amount, false).unwrap();
 
-                    assert_eq!(input_blaster_amount.to_exact(), "0.000000093");
+                    assert_eq!(input_blaster_amount.to_exact(), "9.3E-8");
                 }
             }
         }

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -5,7 +5,7 @@ use uniswap_sdk_core::prelude::*;
 
 /// Represents a list of pairs through which a swap can occur
 #[derive(Clone, PartialEq, Debug)]
-pub struct Route<TInput: CurrencyTrait, TOutput: CurrencyTrait> {
+pub struct Route<TInput: Currency, TOutput: Currency> {
     pub pairs: Vec<Pair>,
     pub path: Vec<Token>,
     /// The input token
@@ -15,7 +15,7 @@ pub struct Route<TInput: CurrencyTrait, TOutput: CurrencyTrait> {
     _mid_price: Option<Price<TInput, TOutput>>,
 }
 
-impl<TInput: CurrencyTrait, TOutput: CurrencyTrait> Route<TInput, TOutput> {
+impl<TInput: Currency, TOutput: Currency> Route<TInput, TOutput> {
     /// Creates an instance of [`Route`].
     ///
     /// ## Arguments

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -1,12 +1,13 @@
 use crate::prelude::{Pair, Route};
 use anyhow::Result;
-use uniswap_sdk_core::prelude::sorted_insert::sorted_insert;
-use uniswap_sdk_core::prelude::{compute_price_impact::compute_price_impact, *};
+use uniswap_sdk_core::prelude::{
+    compute_price_impact::compute_price_impact, sorted_insert::sorted_insert, *,
+};
 
 /// Comparator function to allow sorting of trades by their output amounts, in decreasing order, and
 /// then input amounts in increasing order. i.e. the best trades have the most outputs for the least
 /// inputs and are sorted first.
-pub fn input_output_comparator<TInput: CurrencyTrait, TOutput: CurrencyTrait>(
+pub fn input_output_comparator<TInput: Currency, TOutput: Currency>(
     a: &Trade<TInput, TOutput>,
     b: &Trade<TInput, TOutput>,
 ) -> Ordering {
@@ -37,7 +38,7 @@ pub fn input_output_comparator<TInput: CurrencyTrait, TOutput: CurrencyTrait>(
 
 /// Extension of the input output comparator that also considers other dimensions of the trade in
 /// ranking them.
-pub fn trade_comparator<TInput: CurrencyTrait, TOutput: CurrencyTrait>(
+pub fn trade_comparator<TInput: Currency, TOutput: Currency>(
     a: &Trade<TInput, TOutput>,
     b: &Trade<TInput, TOutput>,
 ) -> Ordering {
@@ -69,7 +70,7 @@ pub struct BestTradeOptions {
 ///
 /// Does not account for slippage, i.e. trades that front run this trade and move the price.
 #[derive(Clone, PartialEq, Debug)]
-pub struct Trade<TInput: CurrencyTrait, TOutput: CurrencyTrait> {
+pub struct Trade<TInput: Currency, TOutput: Currency> {
     /// The route of the trade, i.e. which pairs the trade goes through and the input/output
     /// currencies.
     pub route: Route<TInput, TOutput>,
@@ -86,10 +87,10 @@ pub struct Trade<TInput: CurrencyTrait, TOutput: CurrencyTrait> {
     pub price_impact: Percent,
 }
 
-impl<TInput: CurrencyTrait, TOutput: CurrencyTrait> Trade<TInput, TOutput> {
+impl<TInput: Currency, TOutput: Currency> Trade<TInput, TOutput> {
     pub fn new(
         route: Route<TInput, TOutput>,
-        amount: CurrencyAmount<impl CurrencyTrait>,
+        amount: CurrencyAmount<impl Currency>,
         trade_type: TradeType,
     ) -> Result<Self> {
         let len = route.path.len();
@@ -431,6 +432,7 @@ impl<TInput: CurrencyTrait, TOutput: CurrencyTrait> Trade<TInput, TOutput> {
     }
 }
 
+#[allow(dead_code)]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Switch `HashMap` to `FxHashMap` for performance, update traits from `CurrencyTrait` to `Currency`, and adjust test case assertions for scientific notation. Updated uniswap-sdk-core to version 1.0.0-rc in Cargo.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version to 0.3.0, indicating new features or optimizations.
	- Introduced `rustc-hash` dependency for improved performance in hashing functionalities.
	- Enhanced flexibility in route and trade functionalities by broadening currency type support.

- **Bug Fixes**
	- Improved clarity in test assertions by standardizing the representation of small floating-point numbers.

- **Refactor**
	- Optimized data structures for storing factory addresses to enhance performance.
	- Simplified type constraints in various structures and functions for broader usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->