### PR TITLE
chore: Update uniswap-sdk-core and number handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,11 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy-primitives = { version = "0.8", default-features = false }
-alloy-sol-types = { version = "0.8", default-features = false }
-num-bigint = { version = "0.4", default-features = false }
-num-traits = { version = "0.2.19", default-features = false }
-once_cell = "1.20"
+alloy-primitives = { version = "1.3.1", default-features = false }
+alloy-sol-types = { version = "1.3.1", default-features = false }
+once_cell = "1.21"
 thiserror = { version = "2.0", default-features = false }
-uniswap-sdk-core = "3.6.0"
+uniswap-sdk-core = "5.2.0"
 
 [features]
 default = []

--- a/src/entities/pair.rs
+++ b/src/entities/pair.rs
@@ -2,7 +2,7 @@ use crate::prelude::{Error, *};
 use alloc::string::ToString;
 use alloy_primitives::keccak256;
 use alloy_sol_types::SolValue;
-use num_traits::Zero;
+use uniswap_sdk_core::utils::sqrt::sqrt;
 use uniswap_sdk_core::{prelude::*, token};
 
 /// Computes the address of a Uniswap V2 pair
@@ -352,8 +352,9 @@ impl Pair {
         }
 
         let liquidity = if total_supply.quotient().is_zero() {
-            (token_amounts.0.quotient() * token_amounts.1.quotient()).sqrt()
-                - MINIMUM_LIQUIDITY.clone()
+            let result = token_amounts.0.quotient() * token_amounts.1.quotient();
+            let result = sqrt(result)?;
+            result - MINIMUM_LIQUIDITY.clone()
         } else {
             let amount0 =
                 (token_amounts.0.quotient() * total_supply.quotient()) / self.reserve0().quotient();
@@ -396,8 +397,9 @@ impl Pair {
             if k_last.is_zero() {
                 total_supply.clone()
             } else {
-                let root_k = (self.reserve0().quotient() * self.reserve1().quotient()).sqrt();
-                let root_k_last = k_last.sqrt();
+                let root_k = self.reserve0().quotient() * self.reserve1().quotient();
+                let root_k = sqrt(root_k)?;
+                let root_k_last = sqrt(k_last)?;
                 if root_k > root_k_last {
                     let numerator = total_supply.quotient() * (&root_k - &root_k_last);
                     let denominator = root_k * FIVE.clone() + root_k_last;

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -1,7 +1,6 @@
 use crate::prelude::{Error, *};
 use alloc::vec;
 use core::cmp::Ordering;
-use num_traits::Zero;
 use uniswap_sdk_core::prelude::*;
 
 #[allow(clippy::too_long_first_doc_paragraph)]


### PR DESCRIPTION
This commit updates the core dependencies, most notably `uniswap-sdk-core` and `alloy-primitives`/`alloy-sol-types`, to their latest stable versions. These updates necessitated a refactoring of how large integer arithmetic and square root operations are performed within the codebase, specifically migrating from `num-bigint` and `num-traits`.

*   Upgrade `uniswap-sdk-core` to `5.2.0`.
*   Update `alloy-primitives` and `alloy-sol-types` to `1.3.1`.
*   Remove `num-bigint` and `num-traits` dependencies.
*   Refactor `Pair` entity to use `uniswap-sdk-core::utils::sqrt::sqrt`.
*   Rewrite `from_big_int` in `router.rs` for `uniswap-sdk-core::BigInt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standard library support enabled for core SDK components.
- Bug Fixes
  - More robust handling of square-root operations to prevent runtime errors during liquidity minting and valuation.
- Refactor
  - Migrated big-integer handling to unified SDK primitives for consistency and reliability.
  - Removed unused imports for cleaner builds.
- Chores
  - Upgraded key dependencies (core primitives and SDK) to newer versions.
  - Removed legacy numeric libraries to reduce bloat and improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->