### PR TITLE
chore!: bump version to 2.0.0 and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v2-sdk"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V2 SDK for Rust"
@@ -14,13 +14,11 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy-primitives = { version = "0.8", default-features = false }
-alloy-sol-types = { version = "0.8", default-features = false }
-num-bigint = { version = "0.4", default-features = false }
-num-traits = { version = "0.2.19", default-features = false }
-once_cell = "1.20"
+alloy-primitives = { version = "1.3", default-features = false }
+alloy-sol-types = { version = "1.3", default-features = false }
+once_cell = "1.21"
 thiserror = { version = "2.0", default-features = false }
-uniswap-sdk-core = "3.6.0"
+uniswap-sdk-core = "5.2.1"
 
 [features]
 default = []

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{b256, Address, B256};
 use once_cell::sync::Lazy;
 use uniswap_sdk_core::prelude::{
-    BigInt, HashMap, Percent, V2_FACTORY_ADDRESS, V2_FACTORY_ADDRESSES,
+    fastnum::i512, BigInt, HashMap, IsPercent, Percent, V2_FACTORY_ADDRESS, V2_FACTORY_ADDRESSES,
 };
 
 pub const FACTORY_ADDRESS: Address = V2_FACTORY_ADDRESS;
@@ -12,13 +12,22 @@ pub static FACTORY_ADDRESS_MAP: Lazy<HashMap<u64, Address>> =
 pub const INIT_CODE_HASH: B256 =
     b256!("96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f");
 
-pub static MINIMUM_LIQUIDITY: Lazy<BigInt> = Lazy::new(|| BigInt::from(1000));
+pub const MINIMUM_LIQUIDITY: BigInt = i512!(1000);
 
 // exports for internal consumption
-pub(crate) static FIVE: Lazy<BigInt> = Lazy::new(|| BigInt::from(5));
-pub(crate) static _997: Lazy<BigInt> = Lazy::new(|| BigInt::from(997));
-pub(crate) static _1000: Lazy<BigInt> = Lazy::new(|| BigInt::from(1000));
-pub(crate) static BASIS_POINTS: Lazy<BigInt> = Lazy::new(|| BigInt::from(10000));
+pub(crate) const FIVE: BigInt = i512!(5);
+pub(crate) const _997: BigInt = i512!(997);
+pub(crate) const _1000: BigInt = i512!(1000);
+pub(crate) const BASIS_POINTS: BigInt = i512!(10000);
 
-pub(crate) static ZERO_PERCENT: Lazy<Percent> = Lazy::new(Percent::default);
-pub(crate) static ONE_HUNDRED_PERCENT: Lazy<Percent> = Lazy::new(|| Percent::new(1, 1));
+pub(crate) const ZERO_PERCENT: Percent = Percent {
+    numerator: BigInt::ZERO,
+    denominator: BigInt::ONE,
+    meta: IsPercent,
+};
+
+pub(crate) const ONE_HUNDRED_PERCENT: Percent = Percent {
+    numerator: BigInt::ONE,
+    denominator: BigInt::ONE,
+    meta: IsPercent,
+};

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -1,7 +1,6 @@
 use crate::prelude::{Error, *};
 use alloc::vec;
 use core::cmp::Ordering;
-use num_traits::Zero;
 use uniswap_sdk_core::prelude::*;
 
 #[allow(clippy::too_long_first_doc_paragraph)]
@@ -98,10 +97,11 @@ impl<TInput: BaseCurrency, TOutput: BaseCurrency> Trade<TInput, TOutput> {
         trade_type: TradeType,
     ) -> Result<Self, Error> {
         let mut token_amount: CurrencyAmount<Token> = amount.wrapped_owned()?;
+        let currency = amount.meta.currency;
         let input_amount: CurrencyAmount<TInput>;
         let output_amount: CurrencyAmount<TOutput>;
         if trade_type == TradeType::ExactInput {
-            assert!(amount.currency.equals(&route.input), "INPUT");
+            assert!(currency.equals(&route.input), "INPUT");
             for pair in &route.pairs {
                 (token_amount, _) = pair.get_output_amount(&token_amount, false)?;
             }
@@ -116,7 +116,7 @@ impl<TInput: BaseCurrency, TOutput: BaseCurrency> Trade<TInput, TOutput> {
                 token_amount.denominator,
             )?;
         } else {
-            assert!(amount.currency.equals(&route.output), "OUTPUT");
+            assert!(currency.equals(&route.output), "OUTPUT");
             for pair in route.pairs.iter().rev() {
                 (token_amount, _) = pair.get_input_amount(&token_amount, false)?;
             }

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,7 +4,6 @@
 use crate::prelude::{Error, *};
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{sol, SolCall};
-use num_bigint::{BigInt, Sign};
 use uniswap_sdk_core::prelude::*;
 
 /// Options for producing the arguments to send call to the router.
@@ -49,13 +48,13 @@ pub fn swap_call_parameters<TInput: BaseCurrency, TOutput: BaseCurrency>(
 
     let deadline = options.deadline;
     let to = options.recipient;
-    let amount_in: U256 = from_big_int(
-        &trade
+    let amount_in: U256 = U256::from_big_int(
+        trade
             .maximum_amount_in(options.allowed_slippage.clone())?
             .quotient(),
     );
-    let amount_out: U256 = from_big_int(
-        &trade
+    let amount_out: U256 = U256::from_big_int(
+        trade
             .minimum_amount_out(options.allowed_slippage)?
             .quotient(),
     );
@@ -171,16 +170,6 @@ pub fn swap_call_parameters<TInput: BaseCurrency, TOutput: BaseCurrency>(
         calldata: calldata.into(),
         value,
     })
-}
-
-#[inline]
-fn from_big_int(x: &BigInt) -> U256 {
-    let (sign, data) = x.to_u64_digits();
-    match sign {
-        Sign::Plus => U256::from_limbs_slice(&data),
-        Sign::NoSign => U256::ZERO,
-        Sign::Minus => -U256::from_limbs_slice(&data),
-    }
 }
 
 sol! {


### PR DESCRIPTION
- Upgrade uniswap-sdk-core to 5.2.1, alloy to 1.3, once_cell to 1.21
- Remove num-bigint and num-traits dependencies
- Convert Lazy statics to const using i512! macro
- Replace custom implementations with upstream utilities
- Eliminate unnecessary clones and references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Released version 2.0.0 with updated constants promoted to compile-time values, removing lazy initialization. This may require minor adjustments when referencing constants.
- Performance
  - Faster startup and reduced overhead by eliminating runtime initialization of numeric constants.
- Refactor
  - Simplified arithmetic across pair and routing logic for cleaner, more efficient calculations.
  - Adopted a standardized square root utility with explicit error handling for improved robustness.
- Chores
  - Upgraded core dependencies (including primitives and SDK core) and removed legacy numeric libraries to streamline the dependency set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->